### PR TITLE
CI: Add metadata for new NVIDIA autotick

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -271,6 +271,7 @@ about:
   doc_url: https://docs.nvidia.com/nvshmem/api/index.html
 
 extra:
+  compute-subdir: nvshmem
   feedstock-name: libnvshmem
   recipe-maintainers:
     - conda-forge/cuda


### PR DESCRIPTION
[ci skip] ***NO_CI***

Adds metadata for the new NVIDIA autotick logic. The [ci skip] ***NO_CI*** should prevent a new build from starting. I would like to see if the autotick bot works before merging #18 